### PR TITLE
review the publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Ansible is included by default in the current GitHub workflow Ubuntu images, whi
 
 The Ansible Galaxy API key, required.
 
+### `galaxy-version`
+
+The version to push to Ansible galaxy, required. e.g. 0.4.0
+
+### role-name
+The name of the role. The value in ``meta/main.yml` is not taken into account when using the url
+
 ## Example usage
 
 Here is a default configuration.
@@ -24,10 +31,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: galaxy
         uses: ome/action-ansible-galaxy-publish@main
         with:
           galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}
+          galaxy-version: ${{  github.ref_name }}
+          role-name: ${{ steps.role-name.outputs.rolename }}
 ```
+
+The role name is usually read from the ``meta/main.yml` file.

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,15 @@ inputs:
   galaxy-api-key:
     description: Ansible galaxy API key
     required: true
+  galaxy-version: The version to push to Ansible galaxy
+    required: true
+  role-name: The name of the role
+    required: true
+
 
 runs:
   using: composite
   steps:
     - name: Import role
-      run: ansible-galaxy role import --api-key ${{ inputs.galaxy-api-key }} ${GITHUB_REPOSITORY%/*} ${GITHUB_REPOSITORY#*/}
+      run: ansible-galaxy role import -vvv --api-key ${{ inputs.galaxy-api-key }}  --branch ${{ inputs.galaxy-version }}  --role-name=${{ inputs.role-name }} ${GITHUB_REPOSITORY%/*} ${GITHUB_REPOSITORY#*/}
       shell: bash


### PR DESCRIPTION
Due to the change in the publication workflow https://github.com/ansible/galaxy/pull/2767/files, the role name is no longer taken from galaxy-info.
see  https://forum.ansible.com/t/ansible-galaxy-s-role-import-enhancements-and-fixes-for-the-new-year/3206/2 for background